### PR TITLE
[FIX] update python command for cyclonedx

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ case $LANGUAGE in
         fi
         pip install cyclonedx-bom
         path="bom.xml"
-        BoMResult=$(cyclonedx-py -o bom.xml)
+        BoMResult=$(cyclonedx-py requirements -o bom.xml)
         ;;
     
     "golang")


### PR DESCRIPTION
CycloneDX for python (https://github.com/CycloneDX/cyclonedx-python) changed the usage of the command-line to have a `command` positional argument. 
This PR updates the CLI usage for creating the SBOM in python.
This change is likely to allow the use of uv as dependency manager in python in the future.